### PR TITLE
Fix turret HP bar wrong way round

### DIFF
--- a/GJL Jam 2022/Assets/Scripts/Game Management/LookAtTarget.cs
+++ b/GJL Jam 2022/Assets/Scripts/Game Management/LookAtTarget.cs
@@ -20,6 +20,6 @@ public class LookAtTarget : MonoBehaviour
 
     private void Update()
     {
-        transform.LookAt(_target);
+        transform.LookAt(2*transform.position - _target.position);
     }
 }


### PR DESCRIPTION
Turret HP bar now starts lowering from the right side, not the left