### PR TITLE
Fix projectiles target minions stuck to player

### DIFF
--- a/GJL Jam 2022/Assets/Prefabs/Damage Jelly.prefab
+++ b/GJL Jam 2022/Assets/Prefabs/Damage Jelly.prefab
@@ -4922,7 +4922,7 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8690292611238724528}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Radius: 1.002338

--- a/GJL Jam 2022/Assets/Prefabs/Freezing Jelly.prefab
+++ b/GJL Jam 2022/Assets/Prefabs/Freezing Jelly.prefab
@@ -4906,7 +4906,7 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4155284570777990458}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Radius: 1.002338

--- a/GJL Jam 2022/Assets/Prefabs/WhiteCell Projectile.prefab
+++ b/GJL Jam 2022/Assets/Prefabs/WhiteCell Projectile.prefab
@@ -108,7 +108,7 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 800798369083468368}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Radius: 1.0023379

--- a/GJL Jam 2022/Assets/Scripts/Player/Shooting Mechanic/DamageJelly.cs
+++ b/GJL Jam 2022/Assets/Scripts/Player/Shooting Mechanic/DamageJelly.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 public class DamageJelly : Projectile
 {
-    protected override void OnCollisionEnter(Collision other)
+    protected override void OnTriggerEnter(Collider other)
     {
         if (other.gameObject.CompareTag("BodyPart")) return;
         if (other.gameObject.CompareTag("Player")) return;

--- a/GJL Jam 2022/Assets/Scripts/Player/Shooting Mechanic/FreezingJelly.cs
+++ b/GJL Jam 2022/Assets/Scripts/Player/Shooting Mechanic/FreezingJelly.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 public class FreezingJelly : Projectile
 {
-    protected override void OnCollisionEnter(Collision other)
+    protected override void OnTriggerEnter(Collider other) 
     {
         if (other.gameObject.CompareTag("BodyPart")) return;
         if (other.gameObject.CompareTag("Player")) return;

--- a/GJL Jam 2022/Assets/Scripts/Player/Shooting Mechanic/Projectile.cs
+++ b/GJL Jam 2022/Assets/Scripts/Player/Shooting Mechanic/Projectile.cs
@@ -43,6 +43,8 @@ public abstract class Projectile : MonoBehaviour
         if (_closestEnemy)
             transform.position =
                 Vector3.MoveTowards(transform.position, _closestEnemy.position, _speed * Time.deltaTime);
+        if (_closestEnemy && _closestEnemy.GetComponent<Collider>().enabled == false)
+            _closestEnemy = GetClosestEnemy();
     }
 
     public void Shoot(Vector3 direction, float force)
@@ -73,8 +75,8 @@ public abstract class Projectile : MonoBehaviour
         return targetTransform;
     }
 
-    protected virtual void OnCollisionEnter(Collision other)
+    protected virtual void OnTriggerEnter(Collider other) 
     {
-        //Destroy(gameObject);
+        //Destroy(gameObject);    
     }
 }

--- a/GJL Jam 2022/Assets/Scripts/Player/Shooting Mechanic/WhiteBloodCellProjectile.cs
+++ b/GJL Jam 2022/Assets/Scripts/Player/Shooting Mechanic/WhiteBloodCellProjectile.cs
@@ -22,7 +22,7 @@ public class WhiteBloodCellProjectile : Projectile
         return targetTransform;
     }
 
-    protected override void OnCollisionEnter(Collision other)
+    protected override void OnTriggerEnter(Collider other)
     {
         var boss = other.gameObject.GetComponent<Boss>();
         var tower = other.gameObject.GetComponent<WhiteCellTower>();
@@ -37,6 +37,6 @@ public class WhiteBloodCellProjectile : Projectile
 
         if (tower) return;
 
-        base.OnCollisionEnter(other);
+        base.OnTriggerEnter(other);
     }
 }


### PR DESCRIPTION
Projectiles also now use triggers instead of colliders to (hopefully) prevent unwanted physics interactions